### PR TITLE
Support upgrading from an alternate style of referencing packages

### DIFF
--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -6,17 +6,17 @@ namespace CentralisedPackageConverter;
 
 public class PackageConverter
 {
-	private IDictionary<string, string> allReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    private IDictionary<string, string> allReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private const string s_DirPackageProps = "Directory.Packages.props";
 
-    public void ProcessConversion( string solutionFolder, bool revert, bool dryRun, bool force )
-	{
+    public void ProcessConversion(string solutionFolder, bool revert, bool dryRun, bool force)
+    {
         var packageConfigPath = Path.Combine(solutionFolder, s_DirPackageProps);
 
         if (dryRun)
             Console.WriteLine("Dry run enabled - no changes will be made on disk.");
 
-		var rootDir = new DirectoryInfo(solutionFolder);
+        var rootDir = new DirectoryInfo(solutionFolder);
 
         // Find all the csproj files to process
         var projects = rootDir.GetFiles("*.*", SearchOption.AllDirectories)
@@ -24,12 +24,12 @@ public class PackageConverter
                               .OrderBy(x => x.Name)
                               .ToList();
 
-        if( ! force && ! dryRun )
+        if (!force && !dryRun)
         {
             Console.WriteLine("WARNING: You are about to make changes to the following project files:");
             projects.ForEach(p => Console.WriteLine($" {p.Name}"));
             Console.WriteLine("Are you sure you want to continue? [y/n]");
-            if( Console.ReadKey().Key != ConsoleKey.Y )
+            if (Console.ReadKey().Key != ConsoleKey.Y)
             {
                 Console.WriteLine("Aborting...");
                 return;
@@ -40,9 +40,9 @@ public class PackageConverter
         if (revert)
             ReadDirectoryPackagePropsFile(packageConfigPath);
 
-        if( revert )
+        if (revert)
         {
-            projects.ForEach( proj => RevertProject(proj, dryRun));
+            projects.ForEach(proj => RevertProject(proj, dryRun));
 
             if (!dryRun)
             {
@@ -81,7 +81,7 @@ public class PackageConverter
         {
             var package = GetAttributeValue(reference, "Include", false);
 
-            if( allReferences.TryGetValue( package, out var version ))
+            if (allReferences.TryGetValue(package, out var version))
             {
                 reference.SetAttributeValue("Version", version);
                 needToWriteChanges = true;
@@ -140,7 +140,7 @@ public class PackageConverter
 
         Console.WriteLine($"Writing {allReferences.Count} refs to {s_DirPackageProps} to {packageConfigPath}...");
 
-        if( dryRun )
+        if (dryRun)
             lines.ForEach(x => Console.WriteLine(x));
         else
             File.WriteAllLines(packageConfigPath, lines);
@@ -154,16 +154,16 @@ public class PackageConverter
     /// <param name="name"></param>
     /// <param name="remove"></param>
     /// <returns></returns>
-    private string? GetAttributeValue( XElement elem, string name, bool remove )
+    private string? GetAttributeValue(XElement elem, string name, bool remove)
     {
-		var attr = elem.Attributes(name);
+        var attr = elem.Attributes(name);
 
-		if( attr != null )
+        if (attr != null)
         {
-			var value = attr.Select(x => x.Value).FirstOrDefault();
-            if( remove )
-				attr.Remove();
-			return value;
+            var value = attr.Select(x => x.Value).FirstOrDefault();
+            if (remove)
+                attr.Remove();
+            return value;
         }
 
         return null;
@@ -174,42 +174,42 @@ public class PackageConverter
     /// </summary>
     /// <param name="csprojFile"></param>
     /// <param name="dryRun"></param>
-	private void ConvertProject( FileInfo csprojFile, bool dryRun)
+	private void ConvertProject(FileInfo csprojFile, bool dryRun)
     {
         Console.WriteLine($"Processing references for {csprojFile.FullName}...");
 
-        var xml = XDocument.Load( csprojFile.FullName);
+        var xml = XDocument.Load(csprojFile.FullName);
 
-		var refs = xml.Descendants("PackageReference");
+        var refs = xml.Descendants("PackageReference");
 
-		bool needToWriteChanges = false;
+        bool needToWriteChanges = false;
 
-		foreach( var reference in refs )
+        foreach (var reference in refs)
         {
-			var package = GetAttributeValue( reference, "Include", false );
-            var version = GetAttributeValue( reference, "Version", true ); 
+            var package = GetAttributeValue(reference, "Include", false);
+            var version = GetAttributeValue(reference, "Version", true);
 
-			if( string.IsNullOrEmpty( package ))
-				continue;
+            if (string.IsNullOrEmpty(package))
+                continue;
 
-			if (!string.IsNullOrEmpty(version))
-			{
+            if (!string.IsNullOrEmpty(version))
+            {
                 needToWriteChanges = true;
 
                 if (allReferences.TryGetValue(package, out var existingVer))
-				{
-					// Existing reference for this package of same or greater version, so skip
-					if (version.CompareTo(existingVer) >= 0)
-						continue;
-				}
+                {
+                    // Existing reference for this package of same or greater version, so skip
+                    if (version.CompareTo(existingVer) >= 0)
+                        continue;
+                }
 
                 Console.WriteLine($" Found new reference: {package} {version}");
-				allReferences[package] = version;
+                allReferences[package] = version;
             }
         }
 
-		if( needToWriteChanges && ! dryRun )
-			xml.Save(csprojFile.FullName);
+        if (needToWriteChanges && !dryRun)
+            xml.Save(csprojFile.FullName);
     }
 }
 

--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -196,11 +196,14 @@ public class PackageConverter
         foreach (var reference in refs)
         {
             var package = GetAttributeValue(reference, "Include", false);
-            var version = GetAttributeValue(reference, "Version", true);
+
+            if (string.IsNullOrEmpty(package))
+                package = GetAttributeValue(reference, "Update", false);
 
             if (string.IsNullOrEmpty(package))
                 continue;
 
+            var version = GetAttributeValue(reference, "Version", true);
             if (!string.IsNullOrEmpty(version))
             {
                 needToWriteChanges = true;

--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -9,6 +9,14 @@ public class PackageConverter
     private IDictionary<string, string> allReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private const string s_DirPackageProps = "Directory.Packages.props";
 
+    private static readonly HashSet<string> s_extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ".csproj",
+        ".vbproj",
+        ".props",
+        ".targets"
+    };
+
     public void ProcessConversion(string solutionFolder, bool revert, bool dryRun, bool force)
     {
         var packageConfigPath = Path.Combine(solutionFolder, s_DirPackageProps);
@@ -20,7 +28,8 @@ public class PackageConverter
 
         // Find all the csproj files to process
         var projects = rootDir.GetFiles("*.*", SearchOption.AllDirectories)
-                              .Where(x => x.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase))
+                              .Where(x => s_extensions.Contains(x.Extension))
+                              .Where(x => !x.Name.Equals(s_DirPackageProps))
                               .OrderBy(x => x.Name)
                               .ToList();
 

--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -187,7 +187,7 @@ public class PackageConverter
     {
         Console.WriteLine($"Processing references for {csprojFile.FullName}...");
 
-        var xml = XDocument.Load(csprojFile.FullName);
+        var xml = XDocument.Load(csprojFile.FullName, LoadOptions.PreserveWhitespace);
 
         var refs = xml.Descendants("PackageReference");
 


### PR DESCRIPTION
Some people, like me, use a slightly different style of package reference, to simulate Central Package Version Management because it didn't used to be available. The form was, in general, to have a bunch of `<PackageReference Update` elements in a central location, and then just use `<PackageReference Include` in the specific project files that needed those references. In order to support that this PR:

* Looks for references in props or targets files, or VB projects
* Considers versions when Update attributes are used instead of Include attributes
* Cleans up unnecessary PackageReference elements that used to just be `<PackageReference Update="Foo" Version="1" />` as they serve no purpose after upgrading.

By way of validation, this code was used to create the changes in https://github.com/davidwengier/Trains.NET/pull/199. The build failure there seems unrelated (though hilariously ironic).

Also the first commit cleans up the whitespace because I have standards 😛
You probably want to review commit-by-commit and ignore the first one, though maybe GitHub will show a reasonable diff if you turn off whitespace?

Oh, this also fixes https://github.com/Webreaper/CentralisedPackageConverter/issues/7