### PR TITLE
Fixed wrong dictionary access

### DIFF
--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -306,7 +306,7 @@ public class PackageConverter
                 this.referencesByConditionThenName[condition] = referencesForCondition;
             }
 
-            if (referencesForCondition.TryGetValue(version, out var existing))
+            if (referencesForCondition.TryGetValue(package, out var existing))
             {
                 // Existing reference for this package of same or greater version, so skip
                 if (version.CompareTo(existing) >= 0)


### PR DESCRIPTION
Here the package names should to be searched for, not the version. The current implementation would lead to wrong versions in the result, since there is searched for a version, where the package name is the key.