### PR TITLE
Initial commit: Added encoding and linewrap options, CPM transitive p…

### DIFF
--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -472,9 +472,6 @@ public class PackageConverterTests
     )
     {
         var packageConverter = new PackageConverter();
-        //var testDirectory = Path.Combine(this.FixtureDirectory, DateTime.Now.Ticks.ToString());
-        //Directory.CreateDirectory(testDirectory);
-        //var csProjPath = Path.Combine(testDirectory, ProjectFile);
         WriteAllText(this.ProjectFilePath, initialProjectContent, encodingWebName);
 
         var options = new CommandLineOptions

--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -610,9 +610,6 @@ public class PackageConverterTests
     )
     {
         var packageConverter = new PackageConverter();
-        //var testDirectory = Path.Combine(this.FixtureDirectory, DateTime.Now.Ticks.ToString());
-        //Directory.CreateDirectory(testDirectory);
-        //var csProjPath = Path.Combine(testDirectory, "Test.csproj");
         WriteAllText(ProjectFilePath, initialProjectContent, encodingWebName);
         WriteAllText(PackagesFilePath, initialPackageContent, encodingWebName);
 

--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -1,52 +1,91 @@
+using System.Text;
+
 namespace CentralisedPackageConverter.Tests;
 
 using FluentAssertions;
 
 public class PackageConverterTests
 {
-    private string fixtureDirectory;
+    private const string ProjectFile = "Test.csproj";
+    private const string PackagesConfigFile = "Directory.Packages.props";
+
+    private static readonly string LineWrap = Environment.NewLine;
+
+    private static readonly string CustomLineWrap = 
+        LineWrap == "\r\n" ? "\n" : "\r\n";
+
+    /// <summary>
+    /// UTF-32, not commonly a default encoding.
+    /// </summary>
+    private static readonly Encoding CustomEncoding = Encoding.UTF32;
+
+    private DirectoryInfo? _testDirectoryInfo;
+
+    private DirectoryInfo TestDirectoryInfo => _testDirectoryInfo ??
+                                               throw new InvalidOperationException(
+                                                   $"Backing field {nameof(_testDirectoryInfo)} has not been initialized with value.");
+
+    private string? _projectFilePath;
+
+    private string ProjectFilePath => _projectFilePath ??
+                                      throw new InvalidOperationException(
+                                          $"Backing field {nameof(_projectFilePath)} has not been initialized with value.");
+
+    private string? _packagesFilePath;
+
+    private string PackagesFilePath => _packagesFilePath ??
+                                       throw new InvalidOperationException(
+                                           $"Backing field {nameof(_packagesFilePath)} has not been initialized with value.");
 
     [SetUp]
     public void SetUp()
     {
-        // TODO modify to support linux and setup a github action
-        this.fixtureDirectory = "c:/temp/CentralisedPackageConverter";
-        if (!Directory.Exists(this.fixtureDirectory))
+        // TODO check if it supports linux correctly (should do, temp folder likely not hard drive)
+        // TODO setup a github action
+
+        var testTimestampBuilder = new StringBuilder(DateTime.Now.ToString("s"))
+            .Replace("-", string.Empty)
+            .Replace(":", string.Empty);
+        var currentTestDirPrefix = "CentralisedPackageConverter_" + 
+                                   TestContext.CurrentContext.Test.ClassName + "_" +
+                                   TestContext.CurrentContext.Test.Name + "_" +
+                                   testTimestampBuilder + "_";
+        _testDirectoryInfo = Directory.CreateTempSubdirectory(currentTestDirPrefix);
+        foreach (var directoryInfo in TestDirectoryInfo.EnumerateDirectories())
         {
-            Directory.CreateDirectory(this.fixtureDirectory);
+            directoryInfo.Delete(true);
         }
-        foreach (var directory in Directory.EnumerateDirectories(this.fixtureDirectory))
-        {
-            Directory.Delete(directory, true);
-        }
+
+        _projectFilePath = Path.Combine(TestDirectoryInfo.FullName, ProjectFile);
+        _packagesFilePath = Path.Combine(TestDirectoryInfo.FullName, PackagesConfigFile);
     }
 
     [Test]
     public void BasicPackageWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -59,28 +98,28 @@ public class PackageConverterTests
     public void CaseInsensitiveVersionAttrWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap + 
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -93,28 +132,28 @@ public class PackageConverterTests
     public void BasicPackageWithRootNamespaceWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap + 
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -127,31 +166,30 @@ public class PackageConverterTests
     public void BasicPackageWithVersionElementWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"">
-      <Version>1.2.3</Version>
-    </PackageReference>
-  </ItemGroup>
-</Project>";
-
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"">" + LineWrap +
+            @"      <Version>1.2.3</Version>" + LineWrap +
+            @"    </PackageReference>" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"">
-    </PackageReference>
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"">" + LineWrap +
+            @"    </PackageReference>" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -164,29 +202,29 @@ public class PackageConverterTests
     public void BasicPackageWithConditionWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -199,38 +237,36 @@ public class PackageConverterTests
     public void DuplicatedPackageWithConditionWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageReference Include=""TestPackage"" Version=""4.5.6"" />
-  </ItemGroup>
-</Project>";
-
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""4.5.6"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
-
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageVersion Include=""TestPackage"" Version=""4.5.6"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""4.5.6"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestWithSingleProject(
             initialProjectContent,
@@ -239,6 +275,189 @@ public class PackageConverterTests
         );
     }
 
+    [Test]
+    public void TransitivePinningWorks()
+    {
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>" + LineWrap + // =true
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent,
+            true
+        );
+    }
+
+    [Test]
+    public void CustomLineWrapsWork()
+    {
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + CustomLineWrap +
+            @"  <ItemGroup>" + CustomLineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + CustomLineWrap +
+            @"  </ItemGroup>" + CustomLineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + CustomLineWrap +
+            @"  <PropertyGroup>" + CustomLineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + CustomLineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + CustomLineWrap +
+            @"  </PropertyGroup>" + CustomLineWrap +
+            @"  <ItemGroup>" + CustomLineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + CustomLineWrap +
+            @"  </ItemGroup>" + CustomLineWrap +
+            @"</Project>" + CustomLineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent,
+            false, 
+            null, 
+            CustomLineWrap);
+    }
+
+    [Test]
+    public void DefaultEncodingWorks()
+    {
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage_äöüß"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage_äöüß"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage_äöüß"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent);
+
+        // Byte order mark, file binaries may start with BOM.
+        var defaultBom = Encoding.Default.GetPreamble();
+
+        var defaultEncodingProjectBinary = defaultBom
+            .Concat(Encoding.Default.GetBytes(expectedProjectContent))
+            .ToArray();
+        var writtenEncodingProjectBinary = File.ReadAllBytes(ProjectFilePath);
+        AssertAreBinariesEqual(defaultEncodingProjectBinary, writtenEncodingProjectBinary, "Same encodings for project file?");
+
+        var defaultEncodingPackagesBinary = defaultBom
+            .Concat(Encoding.Default.GetBytes(expectedPackageContent))
+            .ToArray();
+        var writtenEncodingPackagesBinary = File.ReadAllBytes(PackagesFilePath);
+        AssertAreBinariesEqual(defaultEncodingPackagesBinary, writtenEncodingPackagesBinary, "Same encodings for packages file?");
+    }
+
+
+    [Test]
+    public void CustomEncodingWorks()
+    {
+        Assert.AreNotEqual(CustomEncoding, Encoding.Default, 
+            $"Is custom encoding {CustomEncoding.WebName} different than default {Encoding.Default}?");
+
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage_äöüß"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage_äöüß"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage_äöüß"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent,
+            false,
+            CustomEncoding.WebName);
+
+        // Byte order marks, file binaries may start with BOM.
+        var defaultBom = Encoding.Default.GetPreamble();
+        var customBom = CustomEncoding.GetPreamble();
+
+        var defaultEncodingProjectBinary = defaultBom
+            .Concat(Encoding.Default.GetBytes(expectedProjectContent))
+            .ToArray();
+        var customEncodingProjectBinary = customBom
+            .Concat(CustomEncoding.GetBytes(expectedProjectContent))
+            .ToArray();
+        var projectFileBinary = File.ReadAllBytes(ProjectFilePath);
+        AssertAreBinariesNotEqual(defaultEncodingProjectBinary, projectFileBinary, "Different encodings for project file?");
+        AssertAreBinariesEqual(customEncodingProjectBinary, projectFileBinary, "Is project file binary expected custom encoding binary?");
+
+        var defaultEncodingPackagesBinary = defaultBom
+            .Concat(Encoding.Default.GetBytes(expectedPackageContent))
+            .ToArray();
+        var customEncodingPackagesBinary = customBom
+            .Concat(CustomEncoding.GetBytes(expectedPackageContent))
+            .ToArray();
+        var packagesFileBinary = File.ReadAllBytes(PackagesFilePath);
+        AssertAreBinariesNotEqual(defaultEncodingPackagesBinary, packagesFileBinary, "Different encodings for packages file?");
+        AssertAreBinariesEqual(customEncodingPackagesBinary, packagesFileBinary, "Is packages file binary expected custom encoding binary?");
+    }
+
+
     // TODO these could all be cleaner if the tests were just files on disk
     // something like this generator https://github.com/belav/csharpier/tree/master/Src/CSharpier.Tests.Generators
     // to create the tests that copying files to a temp directory out of the folder structure in here
@@ -246,22 +465,31 @@ public class PackageConverterTests
     private void TestWithSingleProject(
         string initialProjectContent,
         string expectedProjectContent,
-        string expectedPackageContent
+        string expectedPackageContent,
+        bool transitivePinning = false,
+        string? encodingWebName = null,
+        string? lineWrap = null
     )
     {
         var packageConverter = new PackageConverter();
-        var testDirectory = Path.Combine(this.fixtureDirectory, DateTime.Now.Ticks.ToString());
-        Directory.CreateDirectory(testDirectory);
-        var csProjPath = Path.Combine(testDirectory, "Test.csproj");
-        File.WriteAllText(csProjPath, initialProjectContent);
+        //var testDirectory = Path.Combine(this.FixtureDirectory, DateTime.Now.Ticks.ToString());
+        //Directory.CreateDirectory(testDirectory);
+        //var csProjPath = Path.Combine(testDirectory, ProjectFile);
+        WriteAllText(this.ProjectFilePath, initialProjectContent, encodingWebName);
 
-        packageConverter.ProcessConversion(testDirectory, false, false, true, false);
+        var options = new CommandLineOptions
+        {
+            RootDirectory = TestDirectoryInfo.FullName,
+            Force = true,
+            TransitivePinning = transitivePinning,
+            EncodingWebName = encodingWebName,
+            LineWrap = lineWrap?.Replace("\r", "cr").Replace("\n", "lf")
+        };
+        packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = File.ReadAllText(csProjPath);
+        var newCsProjContent = ReadAllText(this.ProjectFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
-        var packagesContent = File.ReadAllText(
-            Path.Combine(testDirectory, "Directory.Packages.props")
-        );
+        var packagesContent = ReadAllText(this.PackagesFilePath, encodingWebName);
         packagesContent.Should().Be(expectedPackageContent);
     }
 
@@ -269,28 +497,27 @@ public class PackageConverterTests
     public void BasicRevertWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
-
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var initialPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestRevertWithSingleProject(
             initialProjectContent,
@@ -303,28 +530,28 @@ public class PackageConverterTests
     public void BasicRevertWithRootNamespaceWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <ItemGroup>
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var initialPackageContent =
-            @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestRevertWithSingleProject(
             initialProjectContent,
@@ -337,37 +564,37 @@ public class PackageConverterTests
     public void BasicRevertWithConditionWorks()
     {
         var initialProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageReference Include=""TestPackage"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
 
         var expectedProjectContent =
-            @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageReference Include=""TestPackage"" Version=""4.5.6"" />
-  </ItemGroup>
-</Project>";
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""4.5.6"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
         var initialPackageContent =
-            @"<Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">
-    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />
-  </ItemGroup>
-  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">
-    <PackageVersion Include=""TestPackage"" Version=""4.5.6"" />
-  </ItemGroup>
-</Project>
-";
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net6.0' "">" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.2.3"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"  <ItemGroup Condition="" '$(TargetFramework)' == 'net48' "">" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""4.5.6"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
 
         TestRevertWithSingleProject(
             initialProjectContent,
@@ -376,25 +603,96 @@ public class PackageConverterTests
         );
     }
 
+
     private void TestRevertWithSingleProject(
         string initialProjectContent,
         string expectedProjectContent,
-        string initialPackageContent
+        string initialPackageContent,
+        bool transitivePinning = false,
+        string? encodingWebName = null
     )
     {
         var packageConverter = new PackageConverter();
-        var testDirectory = Path.Combine(this.fixtureDirectory, DateTime.Now.Ticks.ToString());
-        Directory.CreateDirectory(testDirectory);
-        var csProjPath = Path.Combine(testDirectory, "Test.csproj");
-        File.WriteAllText(csProjPath, initialProjectContent);
-        File.WriteAllText(
-            Path.Combine(testDirectory, "Directory.Packages.props"),
-            initialPackageContent
-        );
+        //var testDirectory = Path.Combine(this.FixtureDirectory, DateTime.Now.Ticks.ToString());
+        //Directory.CreateDirectory(testDirectory);
+        //var csProjPath = Path.Combine(testDirectory, "Test.csproj");
+        WriteAllText(ProjectFilePath, initialProjectContent, encodingWebName);
+        WriteAllText(PackagesFilePath, initialPackageContent, encodingWebName);
 
-        packageConverter.ProcessConversion(testDirectory, true, false, true, false);
+        var options = new CommandLineOptions
+        {
+            RootDirectory = TestDirectoryInfo.FullName,
+            Revert = true,
+            Force = true,
+            TransitivePinning = transitivePinning,
+            EncodingWebName = encodingWebName
+        };
+        packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = File.ReadAllText(csProjPath);
+        var newCsProjContent = ReadAllText(ProjectFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
+        File.Exists(PackagesFilePath).Should().BeFalse();
+    }
+
+
+    /// <summary>
+    /// <see cref="File.ReadAllText(string, Encoding)"/> or
+    /// <see cref="File.ReadAllText(string)"/> if no encoding
+    /// </summary>
+    private static string ReadAllText(string path, string? encodingWebName)
+    {
+        return encodingWebName is null
+            ? File.ReadAllText(path)
+            : File.ReadAllText(path, Encoding.GetEncoding(encodingWebName));
+    }
+
+    /// <summary>
+    /// <see cref="File.WriteAllText(string, string?, Encoding)"/> or
+    /// <see cref="File.WriteAllText(string, string?)"/> if no encoding
+    /// </summary>
+    private static void WriteAllText(string path, string? contents, string? encodingWebName)
+    {
+        if (encodingWebName != null)
+        {
+            File.WriteAllText(path, contents, Encoding.GetEncoding(encodingWebName));
+        }
+        else
+        {
+            File.WriteAllText(path, contents);
+        }
+    }
+
+    private static void AssertAreBinariesEqual(byte[] binary1, byte[] binary2, string? description)
+    {
+        Assert.AreEqual(binary1.Length, binary2.Length, 
+            "Binary lengths are not equal. " + description + GetBinariesString(binary1, binary2));
+        for (int i = 0; i < binary1.Length; i++)
+        {
+            Assert.AreEqual(binary1[i], binary2[i], 
+                $"Binary byte values at position {i} not equal. " + description + GetBinariesString(binary1, binary2));
+        }
+    }
+
+    private static void AssertAreBinariesNotEqual(byte[] binary1, byte[] binary2, string? description)
+    {
+        if (binary1.Length != binary2.Length)
+        {
+            return;
+        }
+
+        if (Enumerable.Range(0, binary1.Length).Any(i => binary1[i] != binary2[i]))
+        {
+            return;
+        }
+        Assert.Fail("Binaries are equal. " + description + GetBinariesString(binary1, binary2));
+    }
+
+    private static string GetBinariesString(byte[] binary1, byte[] binary2)
+    {
+        return Environment.NewLine +
+               "Binary 1: " + Environment.NewLine +
+               string.Join(",", binary1.Select(b => b.ToString("X"))) + Environment.NewLine +
+               "Binary 2: " + Environment.NewLine +
+               string.Join(",", binary2.Select(b => b.ToString("X"))) + Environment.NewLine;
     }
 }

--- a/CentralisedPackageConverter/CmdLineOptions.cs
+++ b/CentralisedPackageConverter/CmdLineOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using CommandLine;
 
 namespace CentralisedPackageConverter;
@@ -6,7 +7,7 @@ namespace CentralisedPackageConverter;
 public class CommandLineOptions
 {
     [Value(0, MetaName = "Root Directory", HelpText = "Root folder to scan for csproj files.", Required = true)]
-    public string? RootDirectory { get; set; }
+    public string RootDirectory { get; set; } = string.Empty;
 
     [Option('r', "revert", HelpText = "Revert from Centralised Package Management to csproj-based versions.")]
     public bool Revert { get; set; }
@@ -19,4 +20,13 @@ public class CommandLineOptions
 
     [Option('m', HelpText = "Merge changes with existing directory file")]
     public bool Merge { get; set; }
+
+    [Option('t', "transitive-pinning", HelpText = "Force versions on transitive dependencies (CentralPackageTransitivePinningEnabled=true)")]
+    public bool TransitivePinning { get; set; }
+
+    [Option('e', "encoding", HelpText = "Encoding of written files, IANA web name (e.g. 'utf-8', 'utf-16'). Default is picked by .NET implementation.")]
+    public string? EncodingWebName { get; set; }
+
+    [Option('l', "linewrap", HelpText = "Line wrap style: 'lf'=Unix, 'crlf'=Windows, 'cr'=Mac. Default is system style." )]
+    public string? LineWrap { get; set; }
 };

--- a/CentralisedPackageConverter/Formatting.cs
+++ b/CentralisedPackageConverter/Formatting.cs
@@ -1,0 +1,69 @@
+﻿using System.Text;
+
+namespace CentralisedPackageConverter;
+
+/// <summary>
+/// Text formats of files.
+/// </summary>
+public static class Formatting
+{
+    private static readonly IReadOnlyDictionary<string, string> LineWrapOptions =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "cr", "\r" },
+            { "lf", "\n" },
+            { "crlf", "\r\n" },
+        };
+
+    /// <summary>
+    /// Get the encoding to use when writing files, by web name or default.
+    /// </summary>
+    /// <param name="encodingWebName">The web name, as in <see cref="Encoding.WebName"/>.</param>
+    public static Encoding GetCommonEncoding(string? encodingWebName)
+    {
+        var encoding = !string.IsNullOrWhiteSpace(encodingWebName)
+            ? Encoding.GetEncoding(encodingWebName)
+            : Encoding.Default;
+        Console.WriteLine("Writing files with encoding: " + encoding.WebName);
+        return encoding;
+    }
+
+    /// <summary>
+    /// Create actual line wrap from command line options value.
+    /// <list type="bullet">
+    /// <item>"cr" => "\r" (Mac)</item>
+    /// <item>"lf" => "\n" (Unix)</item>
+    /// <item>"crlf" => "\r\n" (Windows)</item>
+    /// </list>
+    /// </summary>
+    /// <param name="cmdlineValue">Value passed with -l option.</param>
+    public static string GetLineWrap(string? cmdlineValue)
+    {
+        if (string.IsNullOrEmpty(cmdlineValue))
+        {
+            return Environment.NewLine;
+        }
+
+        if (LineWrapOptions.TryGetValue(cmdlineValue, out var lineWrap))
+        {
+            return lineWrap;
+        }
+
+        throw new InvalidOperationException("Invalid -l --linewrap option value. Possible are: " +
+                                            string.Join(",", LineWrapOptions.Keys.Select(o => $"\"{o}\"")));
+    }
+
+    /// <summary>
+    /// Set all line wraps in <paramref name="text"/> to <paramref name="lineWrap" />.
+    /// </summary>
+    /// <param name="text">Where to format line wraps.</param>
+    /// <param name="lineWrap">The line wrap character(s).</param>
+    public static string FormatLineWraps(string text, string lineWrap)
+    {
+        return new StringBuilder(text)
+            .Replace("\r\n", "\n")
+            .Replace("\r", "\n") // Normalize Windows, Mac to Unix, to get distinct, single char line wraps.
+            .Replace("\n", lineWrap) // replace normalized line wraps by requested.
+            .ToString();
+    }
+}

--- a/CentralisedPackageConverter/Program.cs
+++ b/CentralisedPackageConverter/Program.cs
@@ -7,7 +7,7 @@ try
     {
         var converter = new PackageConverter();
 
-        converter.ProcessConversion(o.RootDirectory, o.Revert, o.DryRun, o.Force, o.Merge);
+        converter.ProcessConversion(o);
 
         Console.WriteLine("Processing Complete.");
     });


### PR DESCRIPTION
…inning with unit tests. New static Formatting class. Command line parameters as PackageConveter ctor parameters. Changed unit test strings to use explicitly defined line wraps, instead of those of the code file.

Also different test file location, using .NET temp directory. Should also work under Linux; when I tested some time ago under Linux, temporary folder/files were created in the Linux tmp direcory, which may be cleared regularly or be in RAM only.