### PR TITLE
NuGetVersion, pick lowest option, directory excludes, tests

### DIFF
--- a/CentralisedPackageConverter.Tests/DirectoryCrawlerTests.cs
+++ b/CentralisedPackageConverter.Tests/DirectoryCrawlerTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace CentralisedPackageConverter.Tests;
+
+public class DirectoryCrawlerTests : FileTestsBase
+{
+    private static readonly DirectoryCrawler DefaultDirectoryCrawler = new(
+        new Regex(CommandLineOptions.DefaultExcludeDirectories),
+        PackageConverter.FileExtensionsRegex);
+
+    [SetUp]
+    public void SetUp()
+    {
+        InitTestFileSettings();
+    }
+
+    [Test]
+    public void FindsAllRelevantFiles()
+    {
+        const int nbrOfDirs = 3;
+
+        using (var stream = File.Create(Path.Combine(TestDirectoryInfo.FullName, "Directory.Build.props")))
+        {
+            stream.Close();
+        }
+        using (var stream = File.Create(Path.Combine(TestDirectoryInfo.FullName, "Directory.Packages.props")))
+        {
+            stream.Close();
+        }
+
+        var expectedProjectFiles = new List<string>();
+        var currentDirectoryInfo = TestDirectoryInfo;
+        for (int i = 1; i <= nbrOfDirs; i++)
+        {
+            currentDirectoryInfo = currentDirectoryInfo.CreateSubdirectory($"Test{i}"); // deeper structure to traverse
+            var path = Path.Combine(currentDirectoryInfo.FullName, $"Test{i}.csproj");
+            using (var stream = File.Create(path)) { stream.Close(); }
+            expectedProjectFiles.Add(path);
+        }
+
+        var expectedFilePaths = new[]
+            {
+                Path.Combine(TestDirectoryInfo.FullName, "Directory.Build.props")
+                // not Directory.Packages.props!
+            }.Concat(expectedProjectFiles)
+            .ToList();
+
+        var foundFilePaths =
+            DefaultDirectoryCrawler.EnumerateRelevantFiles(TestDirectoryInfo, SearchOption.AllDirectories)
+                .Where(fi => fi.Name != "Directory.Packages.props")
+                .Select(fi => fi.FullName).ToList();
+
+        var filesExpectedFound = "Expected: " + LineWrap + string.Join(LineWrap, expectedFilePaths) + LineWrap +
+                                 "Actual: " + LineWrap + string.Join(LineWrap, foundFilePaths);
+        foundFilePaths.Count.Should().Be(expectedFilePaths.Count, "Correct file count? " + LineWrap + 
+                                                                  filesExpectedFound + LineWrap);
+        for (int j = 0; j < expectedFilePaths.Count; j++)
+        {
+            foundFilePaths[j].Should().Be(expectedFilePaths[j], $"file #{j} shall be expected in found files." +
+                                                                LineWrap + filesExpectedFound + LineWrap);
+        }
+    }
+
+
+    [Test]
+    public void NoFilesInExcludedDirectories()
+    {
+        var binDir = TestDirectoryInfo.CreateSubdirectory("bin");
+        using (var stream = File.Create(Path.Combine(binDir.FullName, "bin.csproj")))
+        {
+            stream.Close();
+        }
+
+        var objDir = TestDirectoryInfo.CreateSubdirectory("obj");
+        using (var stream = File.Create(Path.Combine(objDir.FullName, "obj.csproj")))
+        {
+            stream.Close();
+        }
+
+        var dotDir = TestDirectoryInfo.CreateSubdirectory(".dot");
+        using (var stream = File.Create(Path.Combine(dotDir.FullName, "dot.csproj")))
+        {
+            stream.Close();
+        }
+
+        var foundFilePaths =
+            DefaultDirectoryCrawler.EnumerateRelevantFiles(TestDirectoryInfo, SearchOption.AllDirectories)
+                .Select(fi => fi.FullName).ToList();
+
+        var filesExpectedFound = "Found: " + LineWrap + string.Join(LineWrap, foundFilePaths);
+        foundFilePaths.Count.Should().Be(0, "No files found in excluded directories? " + 
+                                            LineWrap + filesExpectedFound + LineWrap);
+    }
+}

--- a/CentralisedPackageConverter.Tests/FileTestsBase.cs
+++ b/CentralisedPackageConverter.Tests/FileTestsBase.cs
@@ -1,0 +1,83 @@
+﻿using System.Text;
+
+namespace CentralisedPackageConverter.Tests;
+
+public abstract class FileTestsBase
+{
+    internal const string ProjectFile = "Test.csproj";
+    internal const string PackagesConfigFile = "Directory.Packages.props";
+
+    protected static readonly string LineWrap = Environment.NewLine;
+
+    private DirectoryInfo? _testDirectoryInfo;
+
+    protected DirectoryInfo TestDirectoryInfo => _testDirectoryInfo ??
+                                                 throw new InvalidOperationException(
+                                                     $"Backing field {nameof(_testDirectoryInfo)} has not been initialized with value.");
+
+    private string? _projectFilePath;
+
+    protected string SolutionFilePath => _projectFilePath ??
+                                        throw new InvalidOperationException(
+                                            $"Backing field {nameof(_projectFilePath)} has not been initialized with value.");
+
+    private string? _packagesFilePath;
+
+    protected string PackagesFilePath => _packagesFilePath ??
+                                         throw new InvalidOperationException(
+                                             $"Backing field {nameof(_packagesFilePath)} has not been initialized with value.");
+
+    protected FileTestsBase()
+    { }
+
+
+    protected virtual void InitTestFileSettings()
+    {
+        // TODO check if it supports linux correctly (should do, temp folder likely not hard drive)
+        // TODO setup a github action
+
+        var testTimestampBuilder = new StringBuilder(DateTime.Now.ToString("s")) // like 'O' without fractional seconds
+            .Replace("-", string.Empty)
+            .Replace(":", string.Empty);
+        var currentTestDirPrefix = "CentralisedPackageConverter_" +
+                                   TestContext.CurrentContext.Test.ClassName + "_" +
+                                   TestContext.CurrentContext.Test.Name.Replace("\"", "_") + "_" + // " occurs in parameterized tests
+                                   testTimestampBuilder + "_";
+        _testDirectoryInfo = Directory.CreateTempSubdirectory(currentTestDirPrefix);
+        foreach (var directoryInfo in TestDirectoryInfo.EnumerateDirectories())
+        {
+            directoryInfo.Delete(true);
+        }
+
+        _projectFilePath = Path.Combine(TestDirectoryInfo.FullName, ProjectFile);
+        _packagesFilePath = Path.Combine(TestDirectoryInfo.FullName, PackagesConfigFile);
+    }
+
+
+    /// <summary>
+    /// <see cref="File.ReadAllText(string, Encoding)"/> or
+    /// <see cref="File.ReadAllText(string)"/> if no encoding
+    /// </summary>
+    protected static string ReadAllText(string path, string? encodingWebName)
+    {
+        return encodingWebName is null
+            ? File.ReadAllText(path)
+            : File.ReadAllText(path, Encoding.GetEncoding(encodingWebName));
+    }
+
+    /// <summary>
+    /// <see cref="File.WriteAllText(string, string?, Encoding)"/> or
+    /// <see cref="File.WriteAllText(string, string?)"/> if no encoding
+    /// </summary>
+    protected static void WriteAllText(string path, string? contents, string? encodingWebName)
+    {
+        if (encodingWebName != null)
+        {
+            File.WriteAllText(path, contents, Encoding.GetEncoding(encodingWebName));
+        }
+        else
+        {
+            File.WriteAllText(path, contents);
+        }
+    }
+}

--- a/CentralisedPackageConverter.Tests/FileTestsBase.cs
+++ b/CentralisedPackageConverter.Tests/FileTestsBase.cs
@@ -17,12 +17,18 @@ public abstract class FileTestsBase
 
     private string? _projectFilePath;
 
-    protected string SolutionFilePath => _projectFilePath ??
+    /// <summary>
+    /// Default project file in test root directory.
+    /// </summary>
+    protected string ProjectFilePath => _projectFilePath ??
                                         throw new InvalidOperationException(
                                             $"Backing field {nameof(_projectFilePath)} has not been initialized with value.");
 
     private string? _packagesFilePath;
 
+    /// <summary>
+    /// Directory.Packages.props file path, in test root directory.
+    /// </summary>
     protected string PackagesFilePath => _packagesFilePath ??
                                          throw new InvalidOperationException(
                                              $"Backing field {nameof(_packagesFilePath)} has not been initialized with value.");

--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -346,7 +346,7 @@ public class PackageConverterTests : FileTestsBase
         var defaultEncodingProjectBinary = defaultBom
             .Concat(Encoding.Default.GetBytes(expectedProjectContent))
             .ToArray();
-        var writtenEncodingProjectBinary = File.ReadAllBytes(SolutionFilePath);
+        var writtenEncodingProjectBinary = File.ReadAllBytes(ProjectFilePath);
         AssertAreBinariesEqual(defaultEncodingProjectBinary, writtenEncodingProjectBinary, "Same encodings for project file?");
 
         var defaultEncodingPackagesBinary = defaultBom
@@ -404,7 +404,7 @@ public class PackageConverterTests : FileTestsBase
         var customEncodingProjectBinary = customBom
             .Concat(CustomEncoding.GetBytes(expectedProjectContent))
             .ToArray();
-        var projectFileBinary = File.ReadAllBytes(SolutionFilePath);
+        var projectFileBinary = File.ReadAllBytes(ProjectFilePath);
         AssertAreBinariesNotEqual(defaultEncodingProjectBinary, projectFileBinary, "Different encodings for project file?");
         AssertAreBinariesEqual(customEncodingProjectBinary, projectFileBinary, "Is project file binary expected custom encoding binary?");
 
@@ -516,7 +516,7 @@ public class PackageConverterTests : FileTestsBase
     )
     {
         var packageConverter = new PackageConverter();
-        WriteAllText(this.SolutionFilePath, initialProjectContent, encodingWebName);
+        WriteAllText(this.ProjectFilePath, initialProjectContent, encodingWebName);
 
         var options = new CommandLineOptions
         {
@@ -528,7 +528,7 @@ public class PackageConverterTests : FileTestsBase
         };
         packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = ReadAllText(this.SolutionFilePath, encodingWebName);
+        var newCsProjContent = ReadAllText(this.ProjectFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
         var packagesContent = ReadAllText(this.PackagesFilePath, encodingWebName);
         packagesContent.Should().Be(expectedPackageContent);
@@ -654,7 +654,7 @@ public class PackageConverterTests : FileTestsBase
     )
     {
         var packageConverter = new PackageConverter();
-        WriteAllText(SolutionFilePath, initialProjectContent, encodingWebName);
+        WriteAllText(ProjectFilePath, initialProjectContent, encodingWebName);
         WriteAllText(PackagesFilePath, initialPackageContent, encodingWebName);
 
         var options = new CommandLineOptions
@@ -667,7 +667,7 @@ public class PackageConverterTests : FileTestsBase
         };
         packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = ReadAllText(SolutionFilePath, encodingWebName);
+        var newCsProjContent = ReadAllText(ProjectFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
         File.Exists(PackagesFilePath).Should().BeFalse();
     }

--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -420,6 +420,88 @@ public class PackageConverterTests : FileTestsBase
     }
 
 
+    [Test]
+    public void FloatingVersionsDontWork()
+    {
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""[2.0.0,]"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""3.0.*"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""(4.0.0,4.0.99]"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap + // =true
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent);
+    }
+
+
+    [Test]
+    public void PreserveCommentsCdataWorks()
+    {
+        var initialProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <!-- XML Comment to test if it is preserved. -->" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <Description><![CDATA[Wrapped CDATA:" + LineWrap + "To demonstrate preservation.]]></Description>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+
+        var expectedProjectContent =
+            @"<Project Sdk=""Microsoft.NET.Sdk"">" + LineWrap +
+            @"  <!-- XML Comment to test if it is preserved. -->" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <Description><![CDATA[Wrapped CDATA:" + LineWrap + "To demonstrate preservation.]]></Description>" + LineWrap +
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>";
+        var expectedPackageContent =
+            @"<Project>" + LineWrap +
+            @"  <PropertyGroup>" + LineWrap +
+            @"    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>" + LineWrap +
+            @"    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>" + LineWrap + // =true
+            @"  </PropertyGroup>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageVersion Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestWithSingleProject(
+            initialProjectContent,
+            expectedProjectContent,
+            expectedPackageContent);
+    }
+
+
     // TODO these could all be cleaner if the tests were just files on disk
     // something like this generator https://github.com/belav/csharpier/tree/master/Src/CSharpier.Tests.Generators
     // to create the tests that copying files to a temp directory out of the folder structure in here

--- a/CentralisedPackageConverter.Tests/PackageConverterTests.cs
+++ b/CentralisedPackageConverter.Tests/PackageConverterTests.cs
@@ -1,16 +1,11 @@
+using FluentAssertions;
 using System.Text;
 
 namespace CentralisedPackageConverter.Tests;
 
-using FluentAssertions;
 
-public class PackageConverterTests
+public class PackageConverterTests : FileTestsBase
 {
-    private const string ProjectFile = "Test.csproj";
-    private const string PackagesConfigFile = "Directory.Packages.props";
-
-    private static readonly string LineWrap = Environment.NewLine;
-
     private static readonly string CustomLineWrap = 
         LineWrap == "\r\n" ? "\n" : "\r\n";
 
@@ -19,46 +14,13 @@ public class PackageConverterTests
     /// </summary>
     private static readonly Encoding CustomEncoding = Encoding.UTF32;
 
-    private DirectoryInfo? _testDirectoryInfo;
-
-    private DirectoryInfo TestDirectoryInfo => _testDirectoryInfo ??
-                                               throw new InvalidOperationException(
-                                                   $"Backing field {nameof(_testDirectoryInfo)} has not been initialized with value.");
-
-    private string? _projectFilePath;
-
-    private string ProjectFilePath => _projectFilePath ??
-                                      throw new InvalidOperationException(
-                                          $"Backing field {nameof(_projectFilePath)} has not been initialized with value.");
-
-    private string? _packagesFilePath;
-
-    private string PackagesFilePath => _packagesFilePath ??
-                                       throw new InvalidOperationException(
-                                           $"Backing field {nameof(_packagesFilePath)} has not been initialized with value.");
 
     [SetUp]
-    public void SetUp()
+    protected void SetUp()
     {
-        // TODO check if it supports linux correctly (should do, temp folder likely not hard drive)
-        // TODO setup a github action
-
-        var testTimestampBuilder = new StringBuilder(DateTime.Now.ToString("s"))
-            .Replace("-", string.Empty)
-            .Replace(":", string.Empty);
-        var currentTestDirPrefix = "CentralisedPackageConverter_" + 
-                                   TestContext.CurrentContext.Test.ClassName + "_" +
-                                   TestContext.CurrentContext.Test.Name + "_" +
-                                   testTimestampBuilder + "_";
-        _testDirectoryInfo = Directory.CreateTempSubdirectory(currentTestDirPrefix);
-        foreach (var directoryInfo in TestDirectoryInfo.EnumerateDirectories())
-        {
-            directoryInfo.Delete(true);
-        }
-
-        _projectFilePath = Path.Combine(TestDirectoryInfo.FullName, ProjectFile);
-        _packagesFilePath = Path.Combine(TestDirectoryInfo.FullName, PackagesConfigFile);
+        InitTestFileSettings();
     }
+
 
     [Test]
     public void BasicPackageWorks()
@@ -384,7 +346,7 @@ public class PackageConverterTests
         var defaultEncodingProjectBinary = defaultBom
             .Concat(Encoding.Default.GetBytes(expectedProjectContent))
             .ToArray();
-        var writtenEncodingProjectBinary = File.ReadAllBytes(ProjectFilePath);
+        var writtenEncodingProjectBinary = File.ReadAllBytes(SolutionFilePath);
         AssertAreBinariesEqual(defaultEncodingProjectBinary, writtenEncodingProjectBinary, "Same encodings for project file?");
 
         var defaultEncodingPackagesBinary = defaultBom
@@ -442,7 +404,7 @@ public class PackageConverterTests
         var customEncodingProjectBinary = customBom
             .Concat(CustomEncoding.GetBytes(expectedProjectContent))
             .ToArray();
-        var projectFileBinary = File.ReadAllBytes(ProjectFilePath);
+        var projectFileBinary = File.ReadAllBytes(SolutionFilePath);
         AssertAreBinariesNotEqual(defaultEncodingProjectBinary, projectFileBinary, "Different encodings for project file?");
         AssertAreBinariesEqual(customEncodingProjectBinary, projectFileBinary, "Is project file binary expected custom encoding binary?");
 
@@ -472,7 +434,7 @@ public class PackageConverterTests
     )
     {
         var packageConverter = new PackageConverter();
-        WriteAllText(this.ProjectFilePath, initialProjectContent, encodingWebName);
+        WriteAllText(this.SolutionFilePath, initialProjectContent, encodingWebName);
 
         var options = new CommandLineOptions
         {
@@ -484,7 +446,7 @@ public class PackageConverterTests
         };
         packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = ReadAllText(this.ProjectFilePath, encodingWebName);
+        var newCsProjContent = ReadAllText(this.SolutionFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
         var packagesContent = ReadAllText(this.PackagesFilePath, encodingWebName);
         packagesContent.Should().Be(expectedPackageContent);
@@ -610,7 +572,7 @@ public class PackageConverterTests
     )
     {
         var packageConverter = new PackageConverter();
-        WriteAllText(ProjectFilePath, initialProjectContent, encodingWebName);
+        WriteAllText(SolutionFilePath, initialProjectContent, encodingWebName);
         WriteAllText(PackagesFilePath, initialPackageContent, encodingWebName);
 
         var options = new CommandLineOptions
@@ -623,38 +585,11 @@ public class PackageConverterTests
         };
         packageConverter.ProcessConversion(options);
 
-        var newCsProjContent = ReadAllText(ProjectFilePath, encodingWebName);
+        var newCsProjContent = ReadAllText(SolutionFilePath, encodingWebName);
         newCsProjContent.Should().Be(expectedProjectContent);
         File.Exists(PackagesFilePath).Should().BeFalse();
     }
 
-
-    /// <summary>
-    /// <see cref="File.ReadAllText(string, Encoding)"/> or
-    /// <see cref="File.ReadAllText(string)"/> if no encoding
-    /// </summary>
-    private static string ReadAllText(string path, string? encodingWebName)
-    {
-        return encodingWebName is null
-            ? File.ReadAllText(path)
-            : File.ReadAllText(path, Encoding.GetEncoding(encodingWebName));
-    }
-
-    /// <summary>
-    /// <see cref="File.WriteAllText(string, string?, Encoding)"/> or
-    /// <see cref="File.WriteAllText(string, string?)"/> if no encoding
-    /// </summary>
-    private static void WriteAllText(string path, string? contents, string? encodingWebName)
-    {
-        if (encodingWebName != null)
-        {
-            File.WriteAllText(path, contents, Encoding.GetEncoding(encodingWebName));
-        }
-        else
-        {
-            File.WriteAllText(path, contents);
-        }
-    }
 
     private static void AssertAreBinariesEqual(byte[] binary1, byte[] binary2, string? description)
     {

--- a/CentralisedPackageConverter.Tests/VersioningTests.cs
+++ b/CentralisedPackageConverter.Tests/VersioningTests.cs
@@ -151,7 +151,7 @@ public class VersioningTests : FileTestsBase
         foreach (var initialProjectContent in initialProjectContents)
         {
             counter++;
-            var directory = Path.Combine(this.SolutionFilePath, $"Test{counter}");
+            var directory = Path.Combine(this.TestDirectoryInfo.FullName, $"Test{counter}");
             Directory.CreateDirectory(directory);
             var filePath = Path.Combine(directory, string.Format(ProjectFileTemplate, counter));
             _projectFilePaths.Add(filePath);

--- a/CentralisedPackageConverter.Tests/VersioningTests.cs
+++ b/CentralisedPackageConverter.Tests/VersioningTests.cs
@@ -1,0 +1,223 @@
+﻿using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.Versioning;
+
+namespace CentralisedPackageConverter.Tests;
+
+public class VersioningTests : FileTestsBase
+{
+    private const string ProjectFileTemplate = "Test{0}.csproj";
+
+    /// <summary>
+    /// Created project files, full paths, to be stored here.
+    /// </summary>
+    private readonly List<string> _projectFilePaths = new();
+
+
+    [SetUp]
+    public void SetUp()
+    {
+        InitTestFileSettings();
+    }
+
+
+    [Test]
+    [TestCase(false, Description = "Max version")]
+    [TestCase(true, Description = "Min version")]
+    public void VersioningPickRegular(bool pickLowest)
+    {
+        var initialProjectContent =
+            @"<Project>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""0.0.0"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""5.3.10"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.9.92"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""10.1.11"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""10.1.10"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""10.0.11"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        var expectedVersion = pickLowest
+            ? "0.0.0"
+            : "10.1.11";
+        TestResultVersion(new [] { initialProjectContent }, expectedVersion, pickLowest);
+        CheckProjectFilesHaveVersionsRemoved();
+    }
+
+
+    [Test]
+    [TestCase(false, Description = "Max version")]
+    [TestCase(true, Description = "Min version")]
+    public void VersioningPickRegularMultipleFiles(bool pickLowest)
+    {
+        var initialProjectContentTemplate =
+            @"<Project>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""{0}"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        var versions = new[]
+        {
+            "0.0.0", "5.3.10", "2.9.92", "10.1.11", "10.1.10", "10.0.11"
+        };
+        var initialProjectContents = versions.Select(v => string.Format(initialProjectContentTemplate, v))
+            .ToList();
+
+        var expectedVersion = pickLowest
+            ? "0.0.0"
+            : "10.1.11";
+
+        TestResultVersion(initialProjectContents, expectedVersion, pickLowest);
+        CheckProjectFilesHaveVersionsRemoved();
+    }
+
+
+    [Test]
+    [TestCase(VersionComparison.Default, "2.0.0", Description = "Default, release in comparison: prefer regular version over prerelease")]
+    [TestCase(VersionComparison.Version, "2.0.0-prerelease.1", Description = "Version only in comparison: regular and prerelease equal (pick first).")]
+    [TestCase(VersionComparison.VersionRelease, "2.0.0", Description = "Release in comparison: prefer regular version over prerelease")]
+    public void VersioningByPrerelease(VersionComparison comparison, string expectedVersion)
+    {
+        var initialProjectContent =
+            @"<Project>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease.1"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease.2"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestResultVersion(new[] { initialProjectContent }, expectedVersion, false, default, comparison);
+        CheckProjectFilesHaveVersionsRemoved();
+    }
+
+    [Test]
+    [TestCase(VersionComparison.Default, "2.0.0-prerelease.1", Description = "Ignore version metadata (pick first).")]
+    [TestCase(VersionComparison.Version, "2.0.0-prerelease.1", Description = "Ignore version metadata (pick first).")]
+    [TestCase(VersionComparison.VersionRelease, "2.0.0-prerelease.1", Description = "Ignore version metadata (pick first).")]
+    [TestCase(VersionComparison.VersionReleaseMetadata, "2.0.0-prerelease.1+metadata.2", Description = "By version metadata, highest.")]
+    public void VersioningByMetadata(VersionComparison comparison, string expectedVersion)
+    {
+        var initialProjectContent =
+            @"<Project>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease.1"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease.1+metadata.1"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease.1+metadata.2"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestResultVersion(new[] { initialProjectContent }, expectedVersion, false, default, comparison);
+        CheckProjectFilesHaveVersionsRemoved();
+    }
+
+    [Test]
+    [TestCase(false, "4.0.0-prerelease+metadata")]
+    [TestCase(true, "3.0.0+metadata")]
+    public void VersioningIgnorePrerelease(bool ignorePrerelease, string expectedVersion)
+    {
+        var initialProjectContent =
+            @"<Project>" + LineWrap +
+            @"  <ItemGroup>" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""1.0.0"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""2.0.0-prerelease"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""3.0.0+metadata"" />" + LineWrap +
+            @"    <PackageReference Include=""TestPackage"" Version=""4.0.0-prerelease+metadata"" />" + LineWrap +
+            @"  </ItemGroup>" + LineWrap +
+            @"</Project>" + LineWrap;
+
+        TestResultVersion(new[] { initialProjectContent }, expectedVersion, false, ignorePrerelease);
+        CheckProjectFilesHaveVersionsRemoved();
+    }
+
+
+
+    // something like this generator https://github.com/belav/csharpier/tree/master/Src/CSharpier.Tests.Generators
+    // to create the tests that copying files to a temp directory out of the folder structure in here
+    // and then do the similar steps to this method
+    private void TestResultVersion(
+        IEnumerable<string> initialProjectContents,
+        string expectedVersionString, 
+        bool pickLowest = default,
+        bool ignorePrerelease = default,
+        VersionComparison comparison = default)
+    {
+        var packageConverter = new PackageConverter();
+
+        var counter = 0;
+        foreach (var initialProjectContent in initialProjectContents)
+        {
+            counter++;
+            var directory = Path.Combine(this.SolutionFilePath, $"Test{counter}");
+            Directory.CreateDirectory(directory);
+            var filePath = Path.Combine(directory, string.Format(ProjectFileTemplate, counter));
+            _projectFilePaths.Add(filePath);
+            WriteAllText(filePath, initialProjectContent, null);
+        }
+
+        var options = new CommandLineOptions
+        {
+            RootDirectory = TestDirectoryInfo.FullName,
+            Force = true,
+            PickMinVersion = pickLowest,
+            IgnorePrerelease = ignorePrerelease,
+            VersionComparison = comparison,
+        };
+        packageConverter.ProcessConversion(options);
+
+        var packagesContent = ReadAllText(this.PackagesFilePath, null);
+        var packagesXml = XDocument.Parse(packagesContent);
+        packagesXml.Root.Should().NotBeNull("Root XML element <Project>... required" + packagesContent);
+        var itemGroup = GetSingleXElement(packagesXml.Root.Elements(), "ItemGroup", packagesContent);
+        var packageVersion = GetSingleXElement(itemGroup.Elements(), "PackageVersion", packagesContent);
+        var versionAttribute = GetSingleXAttribute(packageVersion.Attributes(), "Version", packagesContent);
+        versionAttribute.Value.Should().NotBeNullOrEmpty("'Version' value is required" + packagesContent)
+            .And.Be(expectedVersionString, "Must be the expected 'Version'" + packagesContent);
+    }
+
+    /// <remarks>
+    /// This may need to change, if certain versions are to be preserved (e.g. unused floating, prerelease).
+    /// </remarks>>
+    private void CheckProjectFilesHaveVersionsRemoved()
+    {
+        foreach (var projectFilePath in _projectFilePaths)
+        {
+            var projectContent = ReadAllText(projectFilePath, null);
+            var projectXml = XDocument.Parse(projectContent);
+            var packageReferences = projectXml.Descendants("PackageReference");
+            foreach (var projectReference in packageReferences)
+            {
+                var versionAttributesElements =
+                    projectReference.Attributes("Version").Cast<XObject>()
+                        .Concat(projectReference.Elements("Version"));
+                versionAttributesElements.Any().Should().BeFalse(
+                    "Version attributes/elements should be removed from:{0}{1}{0}",
+                    LineWrap, projectReference.ToString());
+            }
+        }
+    }
+
+
+    private static XElement GetSingleXElement(IEnumerable<XElement>? xElements, string elementName, string assertedDocument)
+    {
+        var xElementsList = xElements
+            ?.Where(xe => StringComparer.Ordinal.Equals(elementName, xe.Name.LocalName))
+            .ToList();
+        xElementsList.Should().NotBeNull("List with XElement '{1}' required {0}{2}{0}", LineWrap, elementName, assertedDocument);
+        xElementsList.Count.Should().Be(1, "One '{1}' XElement required {0}{2}{0}", LineWrap, elementName, assertedDocument);
+        return xElementsList.Single();
+    }
+
+    private static XAttribute GetSingleXAttribute(IEnumerable<XAttribute>? xAttributes, string attributeName, string assertedDocument)
+    {
+        var xAttributesList = xAttributes
+            ?.Where(xa => StringComparer.Ordinal.Equals(attributeName, xa.Name.LocalName))
+            .ToList();
+        xAttributesList.Should().NotBeNull("List with XAttribute '{1}' required {0}{2}{0}", LineWrap, attributeName, assertedDocument);
+        xAttributesList.Count.Should().Be(1, "One '{1}' XAttribute required {0}{2}{0}", LineWrap, attributeName, assertedDocument);
+        return xAttributesList.Single();
+    }
+}

--- a/CentralisedPackageConverter.sln
+++ b/CentralisedPackageConverter.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 25.0.1703.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentralisedPackageConverter", "CentralisedPackageConverter\CentralisedPackageConverter.csproj", "{E98A0B53-9897-413A-A337-2E41BBA35027}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentralisedPackageConverter", "CentralisedPackageConverter\CentralisedPackageConverter.csproj", "{E98A0B53-9897-413A-A337-2E41BBA35027}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CentralisedPackageConverter.Tests", "CentralisedPackageConverter.Tests\CentralisedPackageConverter.Tests.csproj", "{7C2FAF55-03F2-49CF-9C6A-6B4398BF6321}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentralisedPackageConverter.Tests", "CentralisedPackageConverter.Tests\CentralisedPackageConverter.Tests.csproj", "{7C2FAF55-03F2-49CF-9C6A-6B4398BF6321}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{28D37E0F-1DC1-4AC9-BAA7-7CD45AB1E1A8}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/CentralisedPackageConverter/CentralisedPackageConverter.csproj
+++ b/CentralisedPackageConverter/CentralisedPackageConverter.csproj
@@ -22,4 +22,11 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>CentralisedPackageConverter.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/CentralisedPackageConverter/CentralisedPackageConverter.csproj
+++ b/CentralisedPackageConverter/CentralisedPackageConverter.csproj
@@ -20,5 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/CentralisedPackageConverter/CmdLineOptions.cs
+++ b/CentralisedPackageConverter/CmdLineOptions.cs
@@ -5,13 +5,16 @@ namespace CentralisedPackageConverter;
 
 public class CommandLineOptions
 {
-    [Value(0, MetaName = "Root Directory", HelpText = "Root folder to scan for csproj files.", Required = true)]
+    internal const string DefaultExcludeDirectories = "^\\.|^bin$|^obj$";
+
+
+    [Value(0, MetaName = "Root Directory", HelpText = "Root folder to scan for .csproj files.", Required = true)]
     public string RootDirectory { get; set; } = string.Empty;
 
     [Option('r', "revert", HelpText = "Revert from Centralised Package Management to csproj-based versions.")]
     public bool Revert { get; set; }
 
-    [Option('d', "dry-run", HelpText = "Read-only mode (make no changes on disk.")]
+    [Option('d', "dry-run", HelpText = "Read-only mode (make no changes on disk).")]
     public bool DryRun { get; set; }
 
     [Option('f', HelpText = "Force changes (don't prompt/check for permission before continuing).")]
@@ -40,4 +43,8 @@ public class CommandLineOptions
             $"{nameof(VersionComparison.Default)}, {nameof(VersionComparison.Version)}, " + 
             $"{nameof(VersionComparison.VersionRelease)}, {nameof(VersionComparison.VersionReleaseMetadata)}")]
     public VersionComparison VersionComparison { get; set; }
+
+    [Option('x', "exclude-dirs", Default = DefaultExcludeDirectories,
+        HelpText = "Exclude directories matching this regular expression (not search pattern!)")]
+    public string ExcludeDirectoriesRegexString { get; set; } = DefaultExcludeDirectories;
 };

--- a/CentralisedPackageConverter/CmdLineOptions.cs
+++ b/CentralisedPackageConverter/CmdLineOptions.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Text;
-using CommandLine;
+﻿using CommandLine;
+using NuGet.Versioning;
 
 namespace CentralisedPackageConverter;
 
@@ -29,4 +28,16 @@ public class CommandLineOptions
 
     [Option('l', "linewrap", HelpText = "Line wrap style: 'lf'=Unix, 'crlf'=Windows, 'cr'=Mac. Default is system style." )]
     public string? LineWrap { get; set; }
+
+    [Option('v', "min-version", HelpText = "Pick minimum instead of maximum package version number.")]
+    public bool PickMinVersion { get; set; }
+
+    [Option('p', "ignore-prerelease", HelpText = "Ignore prerelease versions.")]
+    public bool IgnorePrerelease { get; set; }
+
+    [Option('c', "version-comparison", 
+        HelpText = $"Which NuGet version parts to consider (enum {nameof(VersionComparison)}): " +
+            $"{nameof(VersionComparison.Default)}, {nameof(VersionComparison.Version)}, " + 
+            $"{nameof(VersionComparison.VersionRelease)}, {nameof(VersionComparison.VersionReleaseMetadata)}")]
+    public VersionComparison VersionComparison { get; set; }
 };

--- a/CentralisedPackageConverter/DirectoryCrawler.cs
+++ b/CentralisedPackageConverter/DirectoryCrawler.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+
+namespace CentralisedPackageConverter;
+
+public class DirectoryCrawler
+{
+    public Regex ExcludesRegex { get; }
+
+    public Regex FilesRegex { get; }
+
+
+    public DirectoryCrawler(string excludesRegexString, Regex filesRegex)
+    : this(new Regex(excludesRegexString), filesRegex)
+    {
+
+    }
+    public DirectoryCrawler(Regex excludesRegex, Regex filesRegex)
+    {
+        ExcludesRegex = excludesRegex;
+        FilesRegex = filesRegex;
+    }
+
+    /// <summary>
+    /// Enumerate all directories not filtered out by <see cref="ExcludesRegex"/>,
+    /// including <paramref name="startDirectory"/>.
+    /// </summary>
+    public IEnumerable<DirectoryInfo> EnumerateRelevantDirectories(DirectoryInfo startDirectory)
+    {
+        yield return startDirectory;
+
+        foreach (var relevantDir in startDirectory.EnumerateDirectories()
+                     .Where(d => !ExcludesRegex.IsMatch(d.Name)))
+        {
+            foreach (var subdir in EnumerateRelevantDirectories(relevantDir))
+            {
+                yield return subdir;
+            }
+        }
+    }
+
+    public IEnumerable<FileInfo> EnumerateRelevantFiles(DirectoryInfo directory, SearchOption searchOption)
+    {
+        return searchOption == SearchOption.TopDirectoryOnly
+            ? directory.EnumerateFiles().Where(f => FilesRegex.IsMatch(f.Name))
+            : EnumerateRelevantDirectories(directory).SelectMany(d => EnumerateRelevantFiles(d, SearchOption.TopDirectoryOnly));
+    }
+}

--- a/CentralisedPackageConverter/Formatting.cs
+++ b/CentralisedPackageConverter/Formatting.cs
@@ -24,7 +24,6 @@ public static class Formatting
         var encoding = !string.IsNullOrWhiteSpace(encodingWebName)
             ? Encoding.GetEncoding(encodingWebName)
             : Encoding.Default;
-        Console.WriteLine("Writing files with encoding: " + encoding.WebName);
         return encoding;
     }
 

--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -30,7 +30,7 @@ public class PackageConverter
 
         Console.WriteLine("Writing files with encoding: {0}", encoding.WebName);
         Console.WriteLine("Pick lowest version (not max): {0}", versioning.PickMinVersion);
-        Console.WriteLine("{0}: {1}", nameof(VersionComparer), versioning.Comparer);
+        Console.WriteLine("{0}: {1}", nameof(VersionComparison), o.VersionComparison);
 
         var packageConfigPath = Path.Combine(o.RootDirectory, s_DirPackageProps);
 

--- a/CentralisedPackageConverter/Versioning.cs
+++ b/CentralisedPackageConverter/Versioning.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using NuGet.Versioning;
+
+namespace CentralisedPackageConverter;
+
+public class Versioning
+{
+    public bool PickMinVersion { get; }
+
+    public bool IgnorePrerelease { get; }
+
+    public VersionComparer Comparer { get; }
+
+    public Versioning(bool pickMinVersion, bool ignorePrerelease, VersionComparison comparison)
+    {
+        PickMinVersion = pickMinVersion;
+        IgnorePrerelease = ignorePrerelease;
+        Comparer = new VersionComparer(comparison);
+    }
+
+    /// <summary>
+    /// Don't consider the version for PackageVersion setting.
+    /// True if null or has parts not supported by <see cref="Comparer"/>.
+    /// </summary>
+    public bool IgnorePackageVersion([NotNullWhen(false)]SemanticVersion? version)
+    {
+        if (version == null)
+        {
+            return true;
+        }
+
+        return IgnorePrerelease && version.IsPrerelease;
+    }
+
+    /// <summary>
+    /// Use the existing and not the next version for the PackageVersion?
+    /// Preference of greater/lesser versions according to <see cref="PickMinVersion"/>. 
+    /// Consideration of version parts (prerelease, metadata) according to <see cref="Comparer"/>.
+    /// </summary>
+    /// <param name="existingVersion"></param>
+    /// <param name="nextVersion"></param>
+    /// <returns></returns>
+    public bool PreferExisting(SemanticVersion existingVersion, SemanticVersion? nextVersion)
+    {
+        if (nextVersion == null)
+        {
+            return true;
+        }
+
+        return PickMinVersion
+            ? Comparer.Compare(existingVersion, nextVersion) <= 0
+            : Comparer.Compare(existingVersion, nextVersion) >= 0;
+    }
+}

--- a/CentralisedPackageConverter/Versioning.cs
+++ b/CentralisedPackageConverter/Versioning.cs
@@ -22,7 +22,7 @@ public class Versioning
     /// Don't consider the version for PackageVersion setting.
     /// True if null or has parts not supported by <see cref="Comparer"/>.
     /// </summary>
-    public bool IgnorePackageVersion([NotNullWhen(false)]SemanticVersion? version)
+    public bool IgnorePackageVersion([NotNullWhen(false)]NuGetVersion? version)
     {
         if (version == null)
         {
@@ -40,7 +40,7 @@ public class Versioning
     /// <param name="existingVersion"></param>
     /// <param name="nextVersion"></param>
     /// <returns></returns>
-    public bool PreferExisting(SemanticVersion existingVersion, SemanticVersion? nextVersion)
+    public bool PreferExisting(NuGetVersion existingVersion, NuGetVersion? nextVersion)
     {
         if (nextVersion == null)
         {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Central Package Management CPM does not support floating versions, such as wildc
 
 Omitted digits will be implicitly added: *"8" == "8.0" == "8.0.0"*. 
 
+### Incomplete or invalid packages file
+
+The *Directory.Packages.props* file may be invalid or incomplete:
+* if the versions found in projects are missing, invalid (e.g. floating) or ignored (e.g. prerelease).
+* if conditions on *ItemGroup* depend on the project file.
+
+In these cases, manual edits or version selection will be necessary.
+
 ## Credits
 
 Thanks to [Thomas Ardal](https://github.com/ThomasArdal) for the suggestion and pointers to get this pushed as a dotnet global command. 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ from the `csproj` file, and write the entries to the `Directory.Packages.props` 
 
 ## Command-line Options
 
-* `-d` will force the tool to run in 'dry run' mode, meaning no changes will be written to disk.
-* `-r` will reverse the conversion process - writing the versions back to the csproj files, and deleting the `Directory.Package.props` file.
-* `-y` will skip the "Are you sure you want to do this" prompt and make the changes regardless. Be careful!
+* Root Directory : Root folder to scan for csproj files. Required.
+* `-r`, `--revert` : Revert from Centralised Package Management to csproj-based versions.
+* `-d`, `--dry-run` : Read-only mode (make no changes on disk.
+* `-f` : `Force changes (don`t prompt/check for permission before continuing).
+* `-m` : `Merge changes with existing directory file.
+* `-t`, `--transitive-pinning` : Force versions on transitive dependencies (CentralPackageTransitivePinningEnabled=true).
+* `-e`, `--encoding` : Encoding of written files, IANA web name (e.g. `utf-8`, `utf-16`). Default is picked by .NET implementation.
+* `-l`, `--linewrap` : Line wrap style: `lf`=Unix, `crlf`=Windows, `cr`=Mac. Default is system style.
+* `-v`, `--min-version` : Pick minimum instead of maximum package version number.
+* `-p`, `--ignore-prerelease` : Ignore prerelease versions.
+* `-c`, `--version-comparison` : Which NuGet version parts to consider: `Default`, `Version`, `VersionRelease`, `VersionReleaseMetadata` (enum `NuGet.Versioning.VersionComparison`).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,21 @@ from the `csproj` file, and write the entries to the `Directory.Packages.props` 
 * Root Directory : Root folder to scan for csproj files. Required.
 * `-r`, `--revert` : Revert from Centralised Package Management to csproj-based versions.
 * `-d`, `--dry-run` : Read-only mode (make no changes on disk.
-* `-f` : `Force changes (don`t prompt/check for permission before continuing).
-* `-m` : `Merge changes with existing directory file.
+* `-f` : Force changes (don`t prompt/check for permission before continuing).
+* `-m` : Merge changes with existing directory file.
 * `-t`, `--transitive-pinning` : Force versions on transitive dependencies (CentralPackageTransitivePinningEnabled=true).
 * `-e`, `--encoding` : Encoding of written files, IANA web name (e.g. `utf-8`, `utf-16`). Default is picked by .NET implementation.
 * `-l`, `--linewrap` : Line wrap style: `lf`=Unix, `crlf`=Windows, `cr`=Mac. Default is system style.
 * `-v`, `--min-version` : Pick minimum instead of maximum package version number.
 * `-p`, `--ignore-prerelease` : Ignore prerelease versions.
 * `-c`, `--version-comparison` : Which NuGet version parts to consider: `Default`, `Version`, `VersionRelease`, `VersionReleaseMetadata` (enum `NuGet.Versioning.VersionComparison`).
+* `-x`, `--exclude-dirs`, (Default = `^\.|^bin$|^obj$`) Exclude directories matching this regular expression (not search pattern!).
+
+## Comments
+
+Central Package Management CPM does not support floating versions, such as wildcards or range operators. 
+
+Omitted digits will be implicitly added: *"8" == "8.0" == "8.0.0"*. 
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ from the `csproj` file, and write the entries to the `Directory.Packages.props` 
 
 * Root Directory : Root folder to scan for csproj files. Required.
 * `-r`, `--revert` : Revert from Centralised Package Management to csproj-based versions.
-* `-d`, `--dry-run` : Read-only mode (make no changes on disk.
-* `-f` : Force changes (don`t prompt/check for permission before continuing).
+* `-d`, `--dry-run` : Read-only mode (make no changes on disk).
+* `-f` : Force changes (don't prompt/check for permission before continuing).
 * `-m` : Merge changes with existing directory file.
 * `-t`, `--transitive-pinning` : Force versions on transitive dependencies (CentralPackageTransitivePinningEnabled=true).
 * `-e`, `--encoding` : Encoding of written files, IANA web name (e.g. `utf-8`, `utf-16`). Default is picked by .NET implementation.


### PR DESCRIPTION
- Version comparison by _NuGetVersion_ (configurable by command line option)
- Directory filtering by regex: _.*, bin, obj_.
  - _DirectoryCrawler_ class
- Optional pick of lowest version
- Can ignore prerelease versions.