### PR TITLE
Add support for all current supported dotnet versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: |
+          6.0.x
+          7.0.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/CentralisedPackageConverter.Tests/CentralisedPackageConverter.Tests.csproj
+++ b/CentralisedPackageConverter.Tests/CentralisedPackageConverter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/CentralisedPackageConverter/CentralisedPackageConverter.csproj
+++ b/CentralisedPackageConverter/CentralisedPackageConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6; net7</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
Adds support for net6.0 to ensure dotnet tool installs work on all currently supported dotnet versions. Keeps unit tests at net7.0 as this is the latest dotnet version. Before / after of nuget:
![image](https://github.com/Webreaper/CentralisedPackageConverter/assets/1707575/9892e339-362e-47c7-978b-d1e38379bbb1)


Bumps setup-dotnet to v3 to enable support for many versions of dotnet to be installed at once, as documented here: https://github.com/actions/setup-dotnet#:~:text=Multiple%20version%20installation%3A 