### PR TITLE
Fix crash in Spectre console logging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "CentralisedPackageConverter",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:8.0"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "console": "integratedTerminal",
+            "stopAtEntry": false,
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/CentralisedPackageConverter/bin/Debug/net8.0/CentralisedPackageConverter.dll",
+            "cwd": "${workspaceFolder}/CentralisedPackageConverter",
+            "args": [
+                "--dry-run",
+                "${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/CentralisedPackageConverter.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/CentralisedPackageConverter/CentralisedPackageConverter.csproj
+++ b/CentralisedPackageConverter/CentralisedPackageConverter.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Analyzer" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CentralisedPackageConverter/OutputExtensions.cs
+++ b/CentralisedPackageConverter/OutputExtensions.cs
@@ -8,14 +8,14 @@ namespace CentralisedPackageConverter;
 public static class Output
 {
     public static void InfoLine(string message) => InfoLine(message, Array.Empty<object>());
-    public static void InfoLine(string message, params object[] args) => AnsiConsole.MarkupLine($"{message}", args);
+    public static void InfoLine(string message, params object[] args) => AnsiConsole.MarkupLine(Markup.Escape(message), args);
 
     public static void ErrorLine(string message) => ErrorLine(message, Array.Empty<object>());
-    public static void ErrorLine(string message, params object[] args) => AnsiConsole.MarkupLine($"[red]{message}[/]", args);
+    public static void ErrorLine(string message, params object[] args) => AnsiConsole.MarkupLineInterpolated($"[red]{string.Format(message, args)}[/]");
 
     public static void TraceLine(string message) => TraceLine(message, Array.Empty<object>());
-    public static void TraceLine(string message, params object[] args) => AnsiConsole.MarkupLine($"[grey]{message}[/]", args);
+    public static void TraceLine(string message, params object[] args) => AnsiConsole.MarkupLineInterpolated($"[grey]{string.Format(message, args)}[/]");
 
     public static void WarningLine(string message) => WarningLine(message, Array.Empty<object>());
-    public static void WarningLine(string message, params object[] args) => AnsiConsole.MarkupLine($"[yellow]{message}[/]", args);
+    public static void WarningLine(string message, params object[] args) => AnsiConsole.MarkupLineInterpolated($"[yellow]{string.Format(message, args)}[/]");
 }


### PR DESCRIPTION
There was a Spectre.Console usage problem where the string `[y/n]` was being interpreted as color markup.

![image](https://github.com/user-attachments/assets/0d82d423-a210-405a-8cbf-0e42227bcb40)


This PR fixes the bug. I also installed the Spectre.Console Roslyn Analyzers, to help detect potential usage problems in the future. I also took the liberty to add some configuration files for Visual Studio Code ( / GitHub Codespaces) users.