### PR TITLE
add support for F# projects and use optimized directory traversals

### DIFF
--- a/CentralisedPackageConverter.Tests/DirectoryCrawlerTests.cs
+++ b/CentralisedPackageConverter.Tests/DirectoryCrawlerTests.cs
@@ -7,7 +7,7 @@ public class DirectoryCrawlerTests : FileTestsBase
 {
     private static readonly DirectoryCrawler DefaultDirectoryCrawler = new(
         new Regex(CommandLineOptions.DefaultExcludeDirectories),
-        PackageConverter.FileExtensionsRegex);
+        PackageConverter.AllowedFileExtensions);
 
     [SetUp]
     public void SetUp()
@@ -53,7 +53,7 @@ public class DirectoryCrawlerTests : FileTestsBase
 
         var filesExpectedFound = "Expected: " + LineWrap + string.Join(LineWrap, expectedFilePaths) + LineWrap +
                                  "Actual: " + LineWrap + string.Join(LineWrap, foundFilePaths);
-        foundFilePaths.Count.Should().Be(expectedFilePaths.Count, "Correct file count? " + LineWrap + 
+        foundFilePaths.Count.Should().Be(expectedFilePaths.Count, "Correct file count? " + LineWrap +
                                                                   filesExpectedFound + LineWrap);
         for (int j = 0; j < expectedFilePaths.Count; j++)
         {
@@ -89,7 +89,7 @@ public class DirectoryCrawlerTests : FileTestsBase
                 .Select(fi => fi.FullName).ToList();
 
         var filesExpectedFound = "Found: " + LineWrap + string.Join(LineWrap, foundFilePaths);
-        foundFilePaths.Count.Should().Be(0, "No files found in excluded directories? " + 
+        foundFilePaths.Count.Should().Be(0, "No files found in excluded directories? " +
                                             LineWrap + filesExpectedFound + LineWrap);
     }
 }

--- a/CentralisedPackageConverter/CmdLineOptions.cs
+++ b/CentralisedPackageConverter/CmdLineOptions.cs
@@ -8,10 +8,10 @@ public class CommandLineOptions
     internal const string DefaultExcludeDirectories = "^\\.|^bin$|^obj$";
 
 
-    [Value(0, MetaName = "Root Directory", HelpText = "Root folder to scan for .csproj files.", Required = true)]
+    [Value(0, MetaName = "Root Directory", HelpText = "Root folder to scan for project files.", Required = true)]
     public string RootDirectory { get; set; } = string.Empty;
 
-    [Option('r', "revert", HelpText = "Revert from Centralised Package Management to csproj-based versions.")]
+    [Option('r', "revert", HelpText = "Revert from Centralised Package Management to project-file-based versions.")]
     public bool Revert { get; set; }
 
     [Option('d', "dry-run", HelpText = "Read-only mode (make no changes on disk).")]
@@ -29,7 +29,7 @@ public class CommandLineOptions
     [Option('e', "encoding", HelpText = "Encoding of written files, IANA web name (e.g. 'utf-8', 'utf-16'). Default is picked by .NET implementation.")]
     public string? EncodingWebName { get; set; }
 
-    [Option('l', "linewrap", HelpText = "Line wrap style: 'lf'=Unix, 'crlf'=Windows, 'cr'=Mac. Default is system style." )]
+    [Option('l', "linewrap", HelpText = "Line wrap style: 'lf'=Unix, 'crlf'=Windows, 'cr'=Mac. Default is system style.")]
     public string? LineWrap { get; set; }
 
     [Option('v', "min-version", HelpText = "Pick minimum instead of maximum package version number.")]
@@ -38,9 +38,9 @@ public class CommandLineOptions
     [Option('p', "ignore-prerelease", HelpText = "Ignore prerelease versions.")]
     public bool IgnorePrerelease { get; set; }
 
-    [Option('c', "version-comparison", 
+    [Option('c', "version-comparison",
         HelpText = $"Which NuGet version parts to consider (enum {nameof(VersionComparison)}): " +
-            $"{nameof(VersionComparison.Default)}, {nameof(VersionComparison.Version)}, " + 
+            $"{nameof(VersionComparison.Default)}, {nameof(VersionComparison.Version)}, " +
             $"{nameof(VersionComparison.VersionRelease)}, {nameof(VersionComparison.VersionReleaseMetadata)}")]
     public VersionComparison VersionComparison { get; set; }
 

--- a/CentralisedPackageConverter/OutputExtensions.cs
+++ b/CentralisedPackageConverter/OutputExtensions.cs
@@ -8,7 +8,7 @@ namespace CentralisedPackageConverter;
 public static class Output
 {
     public static void InfoLine(string message) => InfoLine(message, Array.Empty<object>());
-    public static void InfoLine(string message, params object[] args) => AnsiConsole.MarkupLine(Markup.Escape(message), args);
+    public static void InfoLine(string message, params object[] args) => AnsiConsole.MarkupLine(message, args);
 
     public static void ErrorLine(string message) => ErrorLine(message, Array.Empty<object>());
     public static void ErrorLine(string message, params object[] args) => AnsiConsole.MarkupLineInterpolated($"[red]{string.Format(message, args)}[/]");

--- a/CentralisedPackageConverter/PackageConverter.cs
+++ b/CentralisedPackageConverter/PackageConverter.cs
@@ -401,13 +401,28 @@ public class PackageConverter
 
             if (!versioning.IgnorePackageVersion(version))
             {
-                Output.InfoLine(" Found new reference: {0} {1} with Condition {2}",
-                    package, version.ToFullString(), condition);
+                if (condition != String.Empty)
+                {
+                    Output.InfoLine(" Found new reference: {0} {1} with Condition {2}",
+                        package, version.ToFullString(), condition);
+                }
+                else
+                {
+                    Output.InfoLine(" Found new reference: {0} {1}",
+                    package, version.ToFullString());
+                }
                 referencesForCondition[package] = version;
             }
             else
             {
-                Output.TraceLine("Ignoring {0} version {1} with condition {2}.", packageReference, version?.ToFullString(), condition);
+                if (condition != String.Empty)
+                {
+                    Output.TraceLine("Ignoring {0} version {1} with condition {2}.", package, version?.ToFullString(), condition);
+                }
+                else
+                {
+                    Output.TraceLine("Ignoring {0} version {1}.", package, version?.ToFullString());
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Converts a project to use [Centralised Package Management](https://devblogs.micr
 
 To convert a large project to centralised package management, you need to:
 
-* Go through all of the csproj files and copy the references into the centralised `Directory.Packages.props` file
-* Remove all the versions from the package reference entries in the csproj files.
+* Go through all of the project files and copy the references into the centralised `Directory.Packages.props` file
+* Remove all the versions from the package reference entries in the project files.
 
 This can be laborious for large projects, hence this tool. 
 
@@ -27,14 +27,14 @@ central-pkg-converter /Users/markotway/SomeAwesomeProject
 
 ## How Does it Work?
 
-Run the command, passing a folder as the only parameter. The tool will scan for all `.csproj` files within that 
+Run the command, passing a folder as the only parameter. The tool will scan for all .NET project files within that 
 folder tree, gather up a list of all of the versioned references in the projects, and will then remove the versions
-from the `csproj` file, and write the entries to the `Directory.Packages.props` file.
+from the project file, and write the entries to the `Directory.Packages.props` file.
 
 ## Command-line Options
 
-* Root Directory : Root folder to scan for csproj files. Required.
-* `-r`, `--revert` : Revert from Centralised Package Management to csproj-based versions.
+* Root Directory : Root folder to scan for project files. Required.
+* `-r`, `--revert` : Revert from Centralised Package Management to project-file-based versions.
 * `-d`, `--dry-run` : Read-only mode (make no changes on disk).
 * `-f` : Force changes (don't prompt/check for permission before continuing).
 * `-m` : Merge changes with existing directory file.


### PR DESCRIPTION
Hi! This implements support for F# projects as well as using some new modern .NET directory traversals to speed up the traversal that was happening before. I've tested this on my own F# projects and it works great!

Results:

```terminal
>dotnet run E:\code\LanguageServerProtocol -t
Writing files with encoding: utf-8
Pick lowest version (not max): False
VersionComparison: Default
WARNING: You are about to make changes to the following project files:
 Ionide.LanguageServerProtocol.fsproj
 Ionide.LanguageServerProtocol.Tests.fsproj
 MetaModelGenerator.fsproj
Are you sure you want to continue? [y/n]
yProcessing references for [green]E:\code\LanguageServerProtocol\src\Ionide.LanguageServerProtocol.fsproj[/]...
 Found new reference: DotNet.ReproducibleBuilds 1.1.1 with Condition
 Found new reference: Ionide.KeepAChangelog.Tasks 0.1.8 with Condition
 Found new reference: Newtonsoft.Json 13.0.1 with Condition
 Found new reference: FSharp.Core 6.0.0 with Condition
 Found new reference: StreamJsonRpc 2.16.36 with Condition
Processing references for [green]E:\code\LanguageServerProtocol\tests\Ionide.LanguageServerProtocol.Tests.fsproj[/]...
 Found new reference: BenchmarkDotNet 0.13.1 with Condition
 Found new reference: Expecto 10.2.1 with Condition
 Found new reference: Expecto.FsCheck 10.2.1 with Condition
 Found new reference: FsCheck 2.16.5 with Condition
 Found new reference: Fabulous.AST 1.0.0-pre12 with Condition 
 Found new reference: GitHubActionsTestLogger 2.0.1 with Condition
 Found new reference: Microsoft.NET.Test.Sdk 17.2.0 with Condition
 Found new reference: YoloDev.Expecto.TestSdk 0.14.3 with Condition
Processing references for [green]E:\code\LanguageServerProtocol\tools\MetaModelGenerator\MetaModelGenerator.fsproj[/]...
 Found new reference: Argu 6.2.4 with Condition
Writing 1 refs to Directory.Packages.props to E:\code\LanguageServerProtocol\Directory.Packages.props...
Processing Complete.